### PR TITLE
feat: add openapi documentation to all endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
         "@nestjs/config": "^3.2.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^7.3.0",
         "reflect-metadata": "^0.2.0",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.0",
@@ -1602,6 +1604,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug=="
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.3.2.tgz",
@@ -1812,6 +1819,25 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.5.tgz",
@@ -1853,6 +1879,38 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
       "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
       "dev": true
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.3.0.tgz",
+      "integrity": "sha512-zLkfKZ+ioYsIZ3dfv7Bj8YHnZMNAGWFUmx2ZDuLp/fBE4P8BSjB7hldzDueFXsmwaPL90v7lgyd82P+s7KME1Q==",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.14.2",
+        "@nestjs/mapped-types": "2.0.5",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "5.11.2"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.3.5",
@@ -2812,8 +2870,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -6038,7 +6095,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -7909,6 +7965,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.11.2.tgz",
+      "integrity": "sha512-jQG0cRgJNMZ7aCoiFofnoojeSaa/+KgWaDlfgs8QN+BXoGMpxeMVY5OEnjq4OlNvF3yjftO8c9GRAgcHlO+u7A=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "@nestjs/config": "^3.2.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.3.0",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './modules/app.module';
 import { ConfigService } from '@nestjs/config';
 
@@ -6,9 +7,18 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);
 
-  // Use the ConfigService to get the port value
-  const port = configService.get<number>('app.port', 3000); // The second parameter is a default value
+  // Swagger Setup
+  const config = new DocumentBuilder()
+    .setTitle(configService.get<string>('app.name') ?? 'Default App Name')
+    .setDescription('The example API description')
+    .setVersion('1.0')
+    .addTag('example')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
 
+  // Server Setup
+  const port = configService.get<number>('app.port', 3000);
   await app.listen(port);
   console.log(`Application is running on: ${await app.getUrl()}`);
 }

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -1,8 +1,14 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ElearningModule } from './elearning/elearning.module';
+import configuration from '../config/configuration';
 
 @Module({
-  imports: [ConfigModule.forRoot(), ElearningModule],
+  imports: [
+    ConfigModule.forRoot({
+      load: [configuration],
+    }),
+    ElearningModule,
+  ],
 })
 export class AppModule {}

--- a/src/modules/elearning/dtos/course.dto.ts
+++ b/src/modules/elearning/dtos/course.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CourseDto {
+  @ApiProperty({ example: '1', description: 'Unique identifier' })
+  id: string;
+
+  @ApiProperty({
+    example: 'Introduction to the admin panel',
+    description: 'Title of the course',
+  })
+  title: string;
+
+  @ApiProperty({
+    example:
+      'An introductory course on the admin panel. Providing you with the basic skills required to setup account, users and alarms',
+    description: 'Course description',
+  })
+  description: string;
+
+  @ApiProperty({
+    example: new Date().toISOString(),
+    description: 'Creation date',
+  })
+  createdAt: Date;
+}

--- a/src/modules/elearning/elearning.controller.spec.ts
+++ b/src/modules/elearning/elearning.controller.spec.ts
@@ -49,7 +49,6 @@ describe('ElearningController', () => {
         id: '1',
         title: 'Test Course',
         description: 'This is a test course',
-        author: 'Test Author',
         createdAt: new Date(),
       };
       jest.spyOn(service, 'create').mockImplementation(() => course);
@@ -64,7 +63,6 @@ describe('ElearningController', () => {
         id: '1',
         title: 'Test Course',
         description: 'This is a test course',
-        author: 'Test Author',
         createdAt: new Date(),
       };
       jest.spyOn(service, 'findOne').mockImplementation(() => course);
@@ -79,7 +77,6 @@ describe('ElearningController', () => {
         id: '1',
         title: 'Updated Course',
         description: 'This is an updated test course',
-        author: 'Updated Author',
         createdAt: new Date(),
       };
       jest.spyOn(service, 'update').mockImplementation(() => course);
@@ -94,7 +91,6 @@ describe('ElearningController', () => {
         id: '1',
         title: 'Patched Course',
         description: 'This is a patched test course',
-        author: 'Patched Author',
         createdAt: new Date(),
       };
       jest.spyOn(service, 'patch').mockImplementation(() => course);

--- a/src/modules/elearning/elearning.controller.ts
+++ b/src/modules/elearning/elearning.controller.ts
@@ -1,5 +1,3 @@
-// src/modules/elearning/elearning.controller.ts
-
 import {
   Body,
   Controller,
@@ -11,38 +9,87 @@ import {
   Put,
 } from '@nestjs/common';
 import { ElearningService } from './elearning.service';
-import { Course } from './interfaces/course.interface';
+import { CourseDto } from './dtos/course.dto';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 
+@ApiTags('courses')
 @Controller('courses')
 export class ElearningController {
   constructor(private readonly elearningService: ElearningService) {}
 
   @Get()
-  findAll(): Course[] {
+  @ApiOperation({ summary: 'Retrieve all courses' })
+  @ApiResponse({
+    status: 200,
+    type: [CourseDto],
+    description: 'Return all courses',
+  })
+  findAll(): CourseDto[] {
     return this.elearningService.findAll();
   }
 
   @Post()
-  create(@Body() course: Course): Course {
-    return this.elearningService.create(course);
+  @ApiOperation({ summary: 'Create a new course' })
+  @ApiBody({ type: CourseDto })
+  @ApiResponse({
+    status: 201,
+    description: 'The course has been successfully created.',
+    type: CourseDto,
+  })
+  create(@Body() courseDto: CourseDto): CourseDto {
+    return this.elearningService.create(courseDto);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string): Course {
+  @ApiOperation({ summary: 'Get a course by id' })
+  @ApiParam({ name: 'id', description: 'The course ID' })
+  @ApiResponse({ status: 200, description: 'Found course', type: CourseDto })
+  findOne(@Param('id') id: string): CourseDto {
     return this.elearningService.findOne(id);
   }
 
   @Put(':id')
-  update(@Param('id') id: string, @Body() course: Course): Course {
-    return this.elearningService.update(id, course);
+  @ApiOperation({ summary: 'Update a course' })
+  @ApiParam({ name: 'id', description: 'The course ID' })
+  @ApiBody({ type: CourseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'The course has been successfully updated.',
+    type: CourseDto,
+  })
+  update(@Param('id') id: string, @Body() courseDto: CourseDto): CourseDto {
+    return this.elearningService.update(id, courseDto);
   }
 
   @Patch(':id')
-  patch(@Param('id') id: string, @Body() course: Partial<Course>): Course {
-    return this.elearningService.patch(id, course);
+  @ApiOperation({ summary: 'Partially update a course' })
+  @ApiParam({ name: 'id', description: 'The course ID' })
+  @ApiBody({ type: CourseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'The course has been successfully updated.',
+    type: CourseDto,
+  })
+  patch(
+    @Param('id') id: string,
+    @Body() courseDto: Partial<CourseDto>,
+  ): CourseDto {
+    return this.elearningService.patch(id, courseDto);
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Delete a course' })
+  @ApiParam({ name: 'id', description: 'The course ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'The course has been successfully deleted.',
+  })
   delete(@Param('id') id: string): void {
     this.elearningService.delete(id);
   }

--- a/src/modules/elearning/elearning.service.spec.ts
+++ b/src/modules/elearning/elearning.service.spec.ts
@@ -19,7 +19,6 @@ describe('ElearningService', () => {
         id: '1',
         title: 'Test Course',
         description: 'This is a test course',
-        author: 'Test Author',
         createdAt: now,
       };
       service.create(course);
@@ -32,14 +31,12 @@ describe('ElearningService', () => {
         id: '1',
         title: 'Test Course 1',
         description: 'This is a test course',
-        author: 'Test Author 1',
         createdAt: now,
       };
       const course2: Course = {
         id: '2',
         title: 'Test Course 2',
         description: 'This is another test course',
-        author: 'Test Author 2',
         createdAt: now,
       };
       service.create(course1);
@@ -57,14 +54,12 @@ describe('ElearningService', () => {
         id: '1',
         title: 'Original Test Course',
         description: 'This is a test course',
-        author: 'Original Author',
         createdAt: now,
       };
       service.create(course);
       const updatedCourse: Course = {
         ...course,
         title: 'Updated Test Course',
-        author: 'Updated Author',
       };
       service.update('1', updatedCourse);
       expect(service.findOne('1')).toEqual(updatedCourse);
@@ -76,7 +71,6 @@ describe('ElearningService', () => {
         id: '1',
         title: 'Original Test Course',
         description: 'This is a test course',
-        author: 'Original Author',
         createdAt: now,
       };
       service.create(course);
@@ -92,7 +86,6 @@ describe('ElearningService', () => {
         id: '1',
         title: 'Test Course to Delete',
         description: 'This course will be deleted',
-        author: 'Deletion Author',
         createdAt: new Date(),
       };
       service.create(course);

--- a/src/modules/elearning/elearning.service.ts
+++ b/src/modules/elearning/elearning.service.ts
@@ -1,39 +1,45 @@
-// src/modules/elearning/elearning.service.ts
-
 import { Injectable } from '@nestjs/common';
-import { Course } from './interfaces/course.interface';
+import { CourseDto } from './dtos/course.dto';
 
 @Injectable()
 export class ElearningService {
-  private readonly courses: Course[] = [];
+  private readonly courses: CourseDto[] = [];
 
-  findAll(): Course[] {
+  findAll(): CourseDto[] {
     return this.courses;
   }
 
-  create(course: Course): Course {
-    this.courses.push(course);
-    return course;
+  create(courseDto: CourseDto): CourseDto {
+    this.courses.push(courseDto);
+    return courseDto;
   }
 
-  findOne(id: string): Course {
+  findOne(id: string): CourseDto {
     return this.courses.find((course) => course.id === id);
   }
 
-  update(id: string, course: Course): Course {
-    const index = this.courses.findIndex((c) => c.id === id);
-    this.courses[index] = course;
-    return course;
+  update(id: string, courseDto: CourseDto): CourseDto {
+    const index = this.courses.findIndex((course) => course.id === id);
+    if (index !== -1) {
+      this.courses[index] = courseDto;
+      return courseDto;
+    }
+    return null; // Consider how you want to handle not found cases
   }
 
-  patch(id: string, course: Partial<Course>): Course {
-    const index = this.courses.findIndex((c) => c.id === id);
-    this.courses[index] = { ...this.courses[index], ...course };
-    return this.courses[index];
+  patch(id: string, courseUpdate: Partial<CourseDto>): CourseDto {
+    const course = this.findOne(id);
+    if (course) {
+      Object.assign(course, courseUpdate);
+      return course;
+    }
+    return null; // Consider how you want to handle not found cases
   }
 
   delete(id: string): void {
-    const index = this.courses.findIndex((c) => c.id === id);
-    this.courses.splice(index, 1);
+    const index = this.courses.findIndex((course) => course.id === id);
+    if (index !== -1) {
+      this.courses.splice(index, 1);
+    }
   }
 }

--- a/src/modules/elearning/interfaces/course.interface.ts
+++ b/src/modules/elearning/interfaces/course.interface.ts
@@ -2,6 +2,5 @@ export interface Course {
   id: string; // Unique identifier
   title: string; // Title of the course
   description: string; // Course description
-  author: string; // Course author
   createdAt: Date; // Creation date
 }


### PR DESCRIPTION
To generate openapi documentation and keep it upto date the documentation is woven into the code. To see the documentation npm run start:dev and then navigate to localhost:3000/api