### PR TITLE
feat(github-actions): add action to enforce conventional commit standards

### DIFF
--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -1,0 +1,41 @@
+name: Enforce Conventional Commits
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Ensure all commits are fetched
+
+      - name: Conventional Commits Checker
+        uses: amannn/action-semantic-pull-request@v3.4.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure to check both PR titles and commit messages
+          validateSingleCommit: true
+          # You can adjust the types to match your workflow and standards
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert


### PR DESCRIPTION
Implement a GitHub Action workflow to ensure all commit messages and pull request titles adhere to the Conventional Commits specification. This addition aims to streamline version management and improve the readability of the project's commit history.